### PR TITLE
Add Uplink config to the configuration file

### DIFF
--- a/main/server.cfg
+++ b/main/server.cfg
@@ -203,6 +203,24 @@ set scr_ctf_waverespawndelay "10"               // Time delay for first respawn 
 set scr_ctf_promode "0"
 
 //////////////////////////////////////////////////
+// UPLINK GAMETYPE SETTINGS                     //
+//////////////////////////////////////////////////
+set scr_ball_armor "100"
+set scr_ball_halftime "10"
+set scr_ball_num_balls "1"
+set scr_ball_numlives "0"
+set scr_ball_playerrespawndelay "0"
+set scr_ball_points_fieldgoal "1"
+set scr_ball_points_touchdown "2"
+set scr_ball_reset_time "15"
+set scr_ball_roundlimit "2"
+set scr_ball_scorelimit "20"
+set scr_ball_timelimit "10"
+set scr_ball_water_drop_delay "10"
+set scr_ball_waverespawndelay "0"
+set scr_ball_winlimit "1"
+
+//////////////////////////////////////////////////
 // INFECTED GAMETYPE SETTINGS                   //
 //////////////////////////////////////////////////
 


### PR DESCRIPTION
Uplink was missing and the default S1X settings are broken, leading to a match that ends after just one point. These settings have been tested on my own server.